### PR TITLE
test and document the filtering function

### DIFF
--- a/src/README.qmd
+++ b/src/README.qmd
@@ -1,7 +1,6 @@
 ---
 title: "Convert iRODS Metadata into a Python dictionary"
 format: gfm
-output-dir: ../
 ---
 
 The `md2dict` module of `mango_mdconverter` creates Python dictionaries
@@ -13,9 +12,17 @@ This can be done:
     + returning value-units tuples if units exist
 - reorganizing the dictionary to bring ManGO schemas together and "analysis" metadata together
 
+You can install this package with `pip`:
+
+```{python}
+pip install mango-mdconverter
+```
+
 The module can be imported like so:
 ```{python}
 from mango_mdconverter import md2dict
+
+# from mango_mdconverter.md2dict import convert_metadata_to_dict # to import a specific function
 ```
 
 ## Example
@@ -117,3 +124,50 @@ reorganized_dict
 
 This function is to be used when converting ManGO metadata into a
 dictionary, in order to export it to a sidecar file, for downloading, or in the context of cold storage.
+
+## Dictionary filtering
+
+The `filter_metadata_dict()` function allows you to filter the metadata dictionary (naive or otherwise) based on the (nested) keys of interest.
+
+Let's say that from the naive metadata dictionary `metadict` we only want the metadata fields from the "mgs" and "mg" namespaces - in that case, the second argument is an array with the desired keys:
+
+```{python}
+md2dict.filter_metadata_dict(metadict, ["mgs", "mg"])
+```
+
+We could do the same with the ManGO-specific organization, to for example select the ManGO schemas and the analysis fields:
+
+```{python}
+md2dict.filter_metadata_dict(reorganized_dict, ["schema", "analysis"])
+```
+
+This level of filtering is equivalent to doing the following:
+
+```{python}
+{k: v for k, v in reorganized_dict.items() if k in ["schema", "analysis"]}
+```
+
+Where this function comes in particularly handy is when you want to filter nested fields. Say, for example, that you want to only retrieve specific schemas and/or specific analysis fields. While our example has only one schema, we can illustrate by selecting only the "title" of the "book" schema, discarding the "author":
+
+```{python}
+
+md2dict.filter_metadata_dict(reorganized_dict, {"schema": {"book": ["title"]}})
+```
+
+We can combine these partial dictionaries with full dictionaries (e.g. all of "analysis") by providing an empty dictionary when we don't want to filter further:
+
+```{python}
+md2dict.filter_metadata_dict(
+    reorganized_dict, {"schema": {"book": ["title"]}, "analysis": {}}
+)
+```
+
+This also works with repeatable composite fields. For example, by selecting only the "pet" and "name" of the "author" composite field, we'll get an array of dictionaries with only the "pet" and "name" keys:
+
+```{python}
+
+md2dict.filter_metadata_dict(
+    reorganized_dict, {"schema": {"book": {"author": ["name", "pet"]}}}
+)
+```
+

--- a/src/mango_mdconverter/md2dict.py
+++ b/src/mango_mdconverter/md2dict.py
@@ -134,13 +134,13 @@ def convert_metadata_to_dict(metadata_items) -> dict:
     return prepare_metadata_for_download(metadict)
 
 
-def filter_metadata_dict(metadict, filters: dict | list = {}) -> dict:
+def filter_metadata_dict(metadict, filters: dict = {}) -> dict:
     """Filter an dictionary of metadata to only retrieve certain keys.
 
     Args:
         metadict (any): Initially, the metadata dictionary, but then
           it is applied recursively to any value within the metadata dictionary.
-        filters (dict, optional): An array or dictionary of keys, indicating which keys of
+        filters (dict or list, optional): An array or dictionary of keys, indicating which keys of
           the metadict should be included. For nested fields, the value should be
           another dict of the same format. Otherwise, an empty dictionary or
           `None` as value is enough. Defaults to `{}`, which results in the

--- a/src/mango_mdconverter/md2dict.py
+++ b/src/mango_mdconverter/md2dict.py
@@ -134,13 +134,13 @@ def convert_metadata_to_dict(metadata_items) -> dict:
     return prepare_metadata_for_download(metadict)
 
 
-def filter_metadata_dict(metadict, filters: dict = {}) -> dict:
+def filter_metadata_dict(metadict, filters: dict | list = {}) -> dict:
     """Filter an dictionary of metadata to only retrieve certain keys.
 
     Args:
         metadict (any): Initially, the metadata dictionary, but then
           it is applied recursively to any value within the metadata dictionary.
-        filters (dict, optional): A dictionary of keys, indicating which keys of
+        filters (dict, optional): An array or dictionary of keys, indicating which keys of
           the metadict should be included. For nested fields, the value should be
           another dict of the same format. Otherwise, an empty dictionary or
           `None` as value is enough. Defaults to `{}`, which results in the
@@ -149,16 +149,24 @@ def filter_metadata_dict(metadict, filters: dict = {}) -> dict:
     Returns:
         dict: A (filtered) dictionary of metadata
     """
+    # no filters = return everything
     if filters is None or len(filters) == 0:
         return metadict
+    # allow array of keys
+    if isinstance(filters, list):
+        filters = {k: {} for k in filters}
     if not isinstance(filters, dict):
-        raise TypeError("The 'filters' argument should be a dictionary or empty.")
+        raise TypeError(
+            "The 'filters' argument should be a dictionary, an array of keys or empty."
+        )
+    # deal with repeatable composite fields
     if isinstance(metadict, list):
         return [filter_metadata_dict(d, filters) for d in metadict]
-    if isinstance(metadict, dict):
-        return {
-            k: filter_metadata_dict(v, filters.get(k, {}))
-            for k, v in metadict.items()
-            if k in filters
-        }
-    return metadict
+
+    if not isinstance(metadict, dict):
+        raise TypeError("The metadata dictionary should be a dict or a list of dicts.")
+    return {
+        k: filter_metadata_dict(v, filters.get(k, {}))
+        for k, v in metadict.items()
+        if k in filters
+    }

--- a/tests/test_md2dict.py
+++ b/tests/test_md2dict.py
@@ -137,3 +137,39 @@ def test_bad_namespacing_conversion(bad_namespacing, bad_namespacing_converted):
     bad_namespacing.reverse()
     reorganized_dict = md2dict.convert_metadata_to_dict(bad_namespacing)
     assert reorganized_dict == bad_namespacing_converted
+
+
+def test_filtering(converted_dict):
+    assert md2dict.filter_metadata_dict(converted_dict) == converted_dict
+
+    only_schemas = md2dict.filter_metadata_dict(converted_dict, ["schema"])
+    assert "schema" in only_schemas
+    assert len(only_schemas) == 1
+    assert only_schemas["schema"] == converted_dict["schema"]
+
+    only_schemas2 = md2dict.filter_metadata_dict(
+        converted_dict, ["schema", "doesnotexist"]
+    )
+    assert "schema" in only_schemas2
+    assert len(only_schemas2) == 1
+    assert only_schemas2["schema"] == converted_dict["schema"]
+
+    only_author = md2dict.filter_metadata_dict(
+        converted_dict, {"schema": {"book": {"author": {}}}}
+    )
+    assert "schema" in only_author
+    assert len(only_author) == 1
+    assert "book" in only_author["schema"]
+    assert "author" in only_author["schema"]["book"]
+    assert len(only_author["schema"]["book"]) == 1
+    assert only_author["schema"] != converted_dict["schema"]
+
+    schema_analysis = md2dict.filter_metadata_dict(
+        converted_dict, ["schema", "analysis"]
+    )
+    assert "schema" in schema_analysis
+    assert schema_analysis["schema"] == converted_dict["schema"]
+    assert "analysis" in schema_analysis
+    assert schema_analysis["analysis"] == converted_dict["analysis"]
+    assert len(schema_analysis) == 2
+    assert schema_analysis != converted_dict


### PR DESCRIPTION
`filter_metadata_dict()` (in principle only relevant for the metadata download in ManGO Portal) needed some documentation and testing.
I also allowed the filters to be arrays of keys when no further filtering is needed.